### PR TITLE
Update Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,8 +9,8 @@ RUN     cd /opt/ \
         && tar xzvf /tmp/circos-0.69-6-kanai.tgz \
         && mv circos-${version} circos \
         && sed -i 's/max_points_per_track = 25000/max_points_per_track = 100000/' /opt/circos/etc/housekeeping.conf \
-        && apk add --update --no-cache perl gd jpeg freetype \
-        && apk add --update --no-cache --virtual=deps make gd-dev jpeg-dev freetype-dev apkbuild-cpan gcc  musl-dev perl-dev \
+        && apk add --update --no-cache perl gd jpeg freetype apkbuild-cpan \
+        && apk add --update --no-cache --virtual=deps make gd-dev jpeg-dev freetype-dev gcc musl-dev perl-dev \
         && wget -O - http://cpanmin.us | perl - --self-upgrade  \
         && cpanm Math::Bezier Math::Round Readonly::Tiny Readonly Config::General Params::Validate Font::TTF::Font Regexp::Common Math::VecStat Text::Format SVG Clone List::MoreUtils  \
         && cpanm -force GD Number::Format \


### PR DESCRIPTION
When I try to run the docker image I get the following error:

```
missing Clone
  error Can't locate Clone.pm in @INC (you may need to install the Clone module) (@INC contains: /opt/circos/bin/lib /opt/circos/bin/../lib /opt/circos/bin /usr/local/lib/perl5/site_perl /usr/local/share/perl5/site_perl /usr/lib/perl5/vendor_perl /usr/share/perl5/vendor_perl /usr/lib/perl5/core_perl /usr/share/perl5/core_perl) at (eval 26) line 1.
```

I believe the reason is that `apkbuild-cpan` is required for `Clone`, but this package is discarded when the virtual package is deleted. Treating it as a non-virtual package fixes this problem for me.